### PR TITLE
:wrench: Fix Help Page config to check right path for xml info

### DIFF
--- a/EvotoApi/Areas/HelpPage/App_Start/HelpPageConfig.cs
+++ b/EvotoApi/Areas/HelpPage/App_Start/HelpPageConfig.cs
@@ -31,7 +31,7 @@ namespace EvotoApi.Areas.HelpPage
         public static void Register(HttpConfiguration config)
         {
             //// Uncomment the following to use the documentation from XML documentation file.
-            if (File.Exists("~/App_Data/XmlDocument.xml"))
+            if (File.Exists(System.Web.Hosting.HostingEnvironment.ApplicationPhysicalPath + "/App_Data/XmlDocument.xml"))
                 config.SetDocumentationProvider(
                     new XmlDocumentationProvider(HttpContext.Current.Server.MapPath("~/App_Data/XmlDocument.xml")));
 


### PR DESCRIPTION
`~` seems to refer to the virtual server path, which doesn't seem to play nicely with `File.Exists`. This changes the help page config to use the physical path that the server's running on for the `File.Exists` check.

![chrome_2017-01-19_18-17-48](https://cloud.githubusercontent.com/assets/5610674/22119677/5ec58124-de74-11e6-96ee-44ffbb828d4b.png)
