### PR TITLE
User specific voting

### DIFF
--- a/EvotoApi/App_Start/Startup.Auth.cs
+++ b/EvotoApi/App_Start/Startup.Auth.cs
@@ -27,6 +27,10 @@ namespace EvotoApi
             {
                 AuthenticationType = DefaultAuthenticationTypes.ApplicationCookie,
                 LoginPath = new PathString("/manage/login"),
+                SlidingExpiration = true,
+                CookieHttpOnly = true,
+                AuthenticationMode = Microsoft.Owin.Security.AuthenticationMode.Active,
+                ExpireTimeSpan = TimeSpan.FromMinutes(30),
                 Provider = new CookieAuthenticationProvider
                 {
                     // Enables the application to validate the security stamp when the user logs in.

--- a/EvotoApi/Areas/Management/Controllers/ManaVotesController.cs
+++ b/EvotoApi/Areas/Management/Controllers/ManaVotesController.cs
@@ -8,27 +8,12 @@ using EvotoApi.Areas.ManagementApi.Models.Request;
 using EvotoApi.Areas.ManagementApi.Models.Response;
 using Management.Database.Interfaces;
 using Management.Models;
-using System.Web.Http.Controllers;
-using System.Threading;
 using Microsoft.AspNet.Identity;
 
 namespace EvotoApi.Areas.ManagementApi.Controllers
 {
-    public class Authorize2 : AuthorizeAttribute
-    {
-        public override void OnAuthorization(HttpActionContext actionContext)
-        {
-            base.OnAuthorization(actionContext);
-        }
-
-        public override Task OnAuthorizationAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
-        {
-            return base.OnAuthorizationAsync(actionContext, cancellationToken);
-        }
-    }
-
     [RoutePrefix("mana/vote")]
-    [Authorize2]
+    [Authorize]
     public class ManaVotesController : ApiController
     {
         private readonly IManaVoteStore _store;
@@ -91,12 +76,11 @@ namespace EvotoApi.Areas.ManagementApi.Controllers
         /// </summary>
         [HttpGet]
         [Route("list")]
-        public async Task<IHttpActionResult> UserList()
+        public async Task<IHttpActionResult> List()
         {
-            var userId = User.Identity.GetUserId<int>();
             try
             {
-                var votes = await _store.GetAllUserVotes(userId);
+                var votes = await _store.GetAllVotes();
                 var response = votes.Select((v) => new ManaVoteResponse(v)).ToList();
                 return Json(response);
             }
@@ -111,12 +95,11 @@ namespace EvotoApi.Areas.ManagementApi.Controllers
         /// </summary>
         [HttpGet]
         [Route("list/{published:bool}")]
-        public async Task<IHttpActionResult> UserList(bool published)
+        public async Task<IHttpActionResult> List(bool published)
         {
-            var userId = User.Identity.GetUserId<int>();
             try
             {
-                var votes = await _store.GetUserVotes(userId, published);
+                var votes = await _store.GetVotes(published);
                 var response = votes.Select((v) => new ManaVoteResponse(v)).ToList();
                 return Json(response);
             }

--- a/EvotoApi/Areas/Management/Models/Request/CreateManaVote.cs
+++ b/EvotoApi/Areas/Management/Models/Request/CreateManaVote.cs
@@ -10,7 +10,7 @@ namespace EvotoApi.Areas.ManagementApi.Models.Request
     {
         [DataMember(Name = "createdBy")]
         [Required]
-        public int CreatedBy { get; private set; }
+        public int CreatedBy { get; set; }
 
         [DataMember(Name = "name")]
         [MinLength(2)]

--- a/EvotoApi/Areas/Management/Web/components/Dashboard.jsx
+++ b/EvotoApi/Areas/Management/Web/components/Dashboard.jsx
@@ -11,7 +11,7 @@ class Dashboard extends React.Component {
   }
 
   fetchVotes () {
-    fetch('/mana/vote/list/user/2', { credentials: 'same-origin' })
+    fetch('/mana/vote/list', { credentials: 'same-origin' })
       .then((res) => res.json())
       .then((data) => {
         this.setState({ votes: data, loaded: true })

--- a/EvotoApi/Areas/Management/Web/components/vote/Edit.jsx
+++ b/EvotoApi/Areas/Management/Web/components/vote/Edit.jsx
@@ -18,13 +18,14 @@ class EditVote extends React.Component {
   }
 
   save (vote, postSave, showErrors) {
-    fetch(`/mana/vote/${this.state.vote.id}/edit`
-      , { method: 'PATCH',
+    fetch(`/mana/vote/${this.state.vote.id}/edit`,
+      { method: 'PATCH',
         body: JSON.stringify(vote),
         headers: {
           'Accept': 'application/json',
           'Content-Type': 'application/json'
-        }
+        },
+        credentials: 'same-origin'
       })
       .then((data) => {
         return data.json()

--- a/EvotoApi/Areas/Management/Web/components/vote/List.jsx
+++ b/EvotoApi/Areas/Management/Web/components/vote/List.jsx
@@ -14,7 +14,7 @@ class VoteList extends React.Component {
   }
 
   fetchVotes () {
-    fetch('/mana/vote/list/user/2', { credentials: 'same-origin' })
+    fetch('/mana/vote/list', { credentials: 'same-origin' })
       .then((res) => res.json())
       .then((data) => {
         this.setState({ votes: data, loaded: true })

--- a/Management.Database/Interfaces/IManaVoteStore.cs
+++ b/Management.Database/Interfaces/IManaVoteStore.cs
@@ -7,8 +7,8 @@ namespace Management.Database.Interfaces
     public interface IManaVoteStore
     {
         Task<ManaVote> GetVoteById(int id);
-        Task<IEnumerable<ManaVote>> GetAllUserVotes(int userId);
-        Task<IEnumerable<ManaVote>> GetUserVotes(int userId, bool published);
+        Task<IEnumerable<ManaVote>> GetAllVotes();
+        Task<IEnumerable<ManaVote>> GetVotes(bool published);
         Task<ManaVote> CreateVote(ManaVote vote);
         Task<ManaVote> UpdateVote(ManaVote vote);
         Task<int> DeleteVote(int id);

--- a/Management.Database/ManagementQueries.Designer.cs
+++ b/Management.Database/ManagementQueries.Designer.cs
@@ -232,20 +232,20 @@ namespace Management.Database {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SELECT * FROM Votes WHERE CreatedBy = @UserId ORDER BY CreationDate DESC.
+        ///   Looks up a localized string similar to SELECT * FROM Votes ORDER BY CreationDate DESC.
         /// </summary>
-        internal static string VotesGetByUser {
+        internal static string VotesGetAll {
             get {
-                return ResourceManager.GetString("VotesGetByUser", resourceCulture);
+                return ResourceManager.GetString("VotesGetAll", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SELECT * FROM Votes WHERE CreatedBy = @UserId AND Published = @Published ORDER BY CreationDate DESC.
+        ///   Looks up a localized string similar to SELECT * FROM Votes WHERE Published = @Published ORDER BY CreationDate DESC.
         /// </summary>
-        internal static string VotesGetByUserAndPublished {
+        internal static string VotesGetByPublished {
             get {
-                return ResourceManager.GetString("VotesGetByUserAndPublished", resourceCulture);
+                return ResourceManager.GetString("VotesGetByPublished", resourceCulture);
             }
         }
         

--- a/Management.Database/ManagementQueries.Designer.cs
+++ b/Management.Database/ManagementQueries.Designer.cs
@@ -232,7 +232,7 @@ namespace Management.Database {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SELECT * FROM Votes WHERE CreatedBy = @UserId.
+        ///   Looks up a localized string similar to SELECT * FROM Votes WHERE CreatedBy = @UserId ORDER BY CreationDate DESC.
         /// </summary>
         internal static string VotesGetByUser {
             get {
@@ -241,7 +241,7 @@ namespace Management.Database {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SELECT * FROM Votes WHERE CreatedBy = @UserId AND Published = @Published.
+        ///   Looks up a localized string similar to SELECT * FROM Votes WHERE CreatedBy = @UserId AND Published = @Published ORDER BY CreationDate DESC.
         /// </summary>
         internal static string VotesGetByUserAndPublished {
             get {

--- a/Management.Database/ManagementQueries.resx
+++ b/Management.Database/ManagementQueries.resx
@@ -127,10 +127,10 @@
     <value>SELECT * FROM Votes WHERE Id = @Id</value>
   </data>
   <data name="VotesGetByUser" xml:space="preserve">
-    <value>SELECT * FROM Votes WHERE CreatedBy = @UserId</value>
+    <value>SELECT * FROM Votes WHERE CreatedBy = @UserId ORDER BY CreationDate DESC</value>
   </data>
   <data name="VotesGetByUserAndPublished" xml:space="preserve">
-    <value>SELECT * FROM Votes WHERE CreatedBy = @UserId AND Published = @Published</value>
+    <value>SELECT * FROM Votes WHERE CreatedBy = @UserId AND Published = @Published ORDER BY CreationDate DESC</value>
   </data>
   <data name="VoteUpdate" xml:space="preserve">
     <value>UPDATE Votes SET Name=@Name, ChainString=@ChainString, Published=@Published, ExpiryDate=@ExpiryDate, Questions=@Questions WHERE Id=@Id</value>

--- a/Management.Database/ManagementQueries.resx
+++ b/Management.Database/ManagementQueries.resx
@@ -126,11 +126,11 @@
   <data name="VoteGetById" xml:space="preserve">
     <value>SELECT * FROM Votes WHERE Id = @Id</value>
   </data>
-  <data name="VotesGetByUser" xml:space="preserve">
-    <value>SELECT * FROM Votes WHERE CreatedBy = @UserId ORDER BY CreationDate DESC</value>
+  <data name="VotesGetAll" xml:space="preserve">
+    <value>SELECT * FROM Votes ORDER BY CreationDate DESC</value>
   </data>
-  <data name="VotesGetByUserAndPublished" xml:space="preserve">
-    <value>SELECT * FROM Votes WHERE CreatedBy = @UserId AND Published = @Published ORDER BY CreationDate DESC</value>
+  <data name="VotesGetByPublished" xml:space="preserve">
+    <value>SELECT * FROM Votes WHERE Published = @Published ORDER BY CreationDate DESC</value>
   </data>
   <data name="VoteUpdate" xml:space="preserve">
     <value>UPDATE Votes SET Name=@Name, ChainString=@ChainString, Published=@Published, ExpiryDate=@ExpiryDate, Questions=@Questions WHERE Id=@Id</value>

--- a/Management.Database/Stores/ManaSqlVoteStore.cs
+++ b/Management.Database/Stores/ManaSqlVoteStore.cs
@@ -17,6 +17,31 @@ namespace Management.Database.Stores
         {
         }
 
+        private async Task<IEnumerable<ManaVote>> GetVoteByQuery(string query)
+        {
+            try
+            {
+                using (var connection = await GetConnectionAsync())
+                {
+                    var result = await connection.QueryAsync(query);
+
+                    if (!result.Any())
+                        throw new RecordNotFoundException();
+
+                    return result.Select((v) => new ManaDbVote(v).ToVote());
+                }
+            }
+            catch (Exception e)
+            {
+#if DEBUG
+                throw;
+#endif
+                if (e is RecordNotFoundException)
+                    throw;
+                throw new Exception("Could not get Mana Vote");
+            }
+        }
+
         private async Task<IEnumerable<ManaVote>> GetVoteByQuery(string query, object parameters)
         {
             try
@@ -48,15 +73,15 @@ namespace Management.Database.Stores
             return vote.First();
         }
 
-        public async Task<IEnumerable<ManaVote>> GetAllUserVotes(int userId)
+        public async Task<IEnumerable<ManaVote>> GetAllVotes()
         {
-            var vote = await GetVoteByQuery(ManagementQueries.VotesGetByUser, new { UserId = userId });
+            var vote = await GetVoteByQuery(ManagementQueries.VotesGetAll);
             return vote;
         }
 
-        public async Task<IEnumerable<ManaVote>> GetUserVotes(int userId, bool published)
+        public async Task<IEnumerable<ManaVote>> GetVotes(bool published)
         {
-            var vote = await GetVoteByQuery(ManagementQueries.VotesGetByUserAndPublished, new { UserId = userId, Published = published });
+            var vote = await GetVoteByQuery(ManagementQueries.VotesGetByPublished, new { Published = published });
             return vote;
         }
 


### PR DESCRIPTION
Finally ties together authorised users to their votes that they make and see.

# 🚨 QUESTION 🚨 
Should we limit the users to only see votes they've made? (That's what this currently does).

Perhaps we should show them both *all* votes *_and_* their own votes on their dashboard? Would sort of make sense as this is for a business level thing?